### PR TITLE
FIX: CSS path & multiple field instances

### DIFF
--- a/code/IconField.php
+++ b/code/IconField.php
@@ -48,7 +48,7 @@ class IconField extends OptionsetField {
 		}
 		
 		$this->source = $icons;		
-		Requirements::css('/resources/jaedb/iconfield/css/IconField.css');
+		Requirements::css('/resources/vendor/jaedb/iconfield/css/IconField.css');
 	}
 	
 

--- a/code/IconField.php
+++ b/code/IconField.php
@@ -63,8 +63,9 @@ class IconField extends OptionsetField {
 		$options = array();
 
 		// Add a clear option
+		$itemID = $this->ID() . '_' . preg_replace('/[^a-zA-Z0-9]/', '', 'none');
 		$options[] = ArrayData::create(array(
-			'ID' => 'none',
+			'ID' => $itemID,
 			'Name' => $this->name,
 			'Value' => '',
 			'Title' => '',


### PR DESCRIPTION
With the current version of Silverstripe 4, the css can be found in `/resources/vendor/jaedb/iconfield/css/IconField.css`

We've also updated the ID of the 'none' option, to allow for multiple instances of the field in the CMS
